### PR TITLE
Fixes dependency array length 0 logging an error.

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,14 @@ Differences from AMD spec:
 
 * Relative module loading is not implemented (if module "a/b/c" asks for "../d", AMD resolves to "a/d"). For this reason:
 * Dependencies are not supported. Use Browserify to bundle up your dependencies prior to loading, or load them yourself.
+
+Development
+-----------
+
+Tests for this module are written in Mocha + Chai & require a web server (such
+as Python's SimpleHTTPServer). To test this module:
+
+1. `npm install` to make sure you have all the dependencies.
+2. `npm run server` to start a web server (this step requires Python, but you
+    can run this from your own web server if you'd prefer).
+3. Open `http://0.0.0.0:8000/test/` in your browser to run the tests.

--- a/index.js
+++ b/index.js
@@ -161,7 +161,7 @@
 			}
 
 			// Fetch any extra dependencies if required
-			if (thisDefine.deps) {
+			if (thisDefine.deps && thisDefine.deps.length) {
 				console.error(
 					'fetchamd: don\'t use second level dependencies',
 					module

--- a/test/requireable3-browserify.js
+++ b/test/requireable3-browserify.js
@@ -1,0 +1,7 @@
+!function(e){"object"==typeof exports?module.exports=e():"function"==typeof define&&define.amd?define(e):"undefined"!=typeof window?window.cake=e():"undefined"!=typeof global?global.cake=e():"undefined"!=typeof self&&(self.cake=e())}(function(){var define,module,exports;return (function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);throw new Error("Cannot find module '"+o+"'")}var f=n[o]={exports:{}};t[o][0].call(f.exports,function(e){var n=t[o][1][e];return s(n?n:e)},f,f.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({1:[function(require,module,exports){
+module.exports = 5;
+
+},{}]},{},[1])
+(1)
+});
+

--- a/test/test.js
+++ b/test/test.js
@@ -61,4 +61,14 @@ describe('Require', function(){
             });
         });
     });
+    it('can load a Browserified standalone module.', function(done){
+        getfetchModule(function(fetchModule){
+            fetchModule(['requireable3-browserify.js'], function(item3){
+                chai.assert(typeof item3, 'number');
+		// item3 exports the number 5.
+                chai.assert(item3, 5);
+                done();
+            });
+        });
+    });
 })


### PR DESCRIPTION
Some modules have no dependencies, but explicitly return an empty array. Browserify does this in --standalone mode. This PR fixes that by checking the array length, and includes tests to capture it in future.

Also some more info in the readme.
