### PR TITLE
Add check for factory, allowing us to pass undefined for non-AMD scripts...

### DIFF
--- a/index.js
+++ b/index.js
@@ -154,7 +154,9 @@
 			var thisDefine = $.extend({}, lastDefine);
 
 			function done(args) {
-				defined[module] = thisDefine.factory.apply(this, args);
+				if(thisDefine && typeof thisDefine.factory === 'function'){
+					defined[module] = thisDefine.factory.apply(this, args);
+				}
 
 				// Reply with the last define we defined.
 				callback(defined[module]);


### PR DESCRIPTION
Basically, if the script we're getting doesn't call define(), don't throw an error, just pass undefined back to the calling script. This way we can also use it like a better $.getScript.
